### PR TITLE
fix: add flush for repository transactions

### DIFF
--- a/src/main/java/com/caronte/caronte/obituary/ObituaryService.java
+++ b/src/main/java/com/caronte/caronte/obituary/ObituaryService.java
@@ -9,11 +9,11 @@ import org.springframework.transaction.annotation.Transactional;
 import com.caronte.caronte.customer.Customer;
 import com.caronte.caronte.customer.CustomerRepository;
 import com.caronte.caronte.deathCertificate.DeathCertificate;
+import com.caronte.caronte.deathCertificate.DeathCertificateService;
 import com.caronte.caronte.imageTemplate.ImageTemplate;
 import com.caronte.caronte.imageTemplate.ImageTemplateService;
 import com.caronte.caronte.receiver.ReceiverService;
 import com.caronte.caronte.util.MediaHandler;
-import com.caronte.caronte.deathCertificate.DeathCertificateService;
 
 @Service
 public class ObituaryService {
@@ -177,8 +177,7 @@ public class ObituaryService {
         obituary.setImageTemplate(imageTemplate);
         obituary.setDeathCertificate(certificate);
         obituary.setWordColor(word_color);
-        obituary = obituaryRepository.save(obituary);
-        obituaryRepository.flush();
+        obituary = obituaryRepository.saveAndFlush(obituary);
         return obituary;
     }
     @Transactional
@@ -199,8 +198,7 @@ public class ObituaryService {
 
     @Transactional
     public Obituary updateObituary(Obituary obituary) {
-        Obituary updatedObituary = obituaryRepository.save(obituary);
-        obituaryRepository.flush();
+        Obituary updatedObituary = obituaryRepository.saveAndFlush(obituary);
         return updatedObituary;
     }
 

--- a/src/main/java/com/caronte/caronte/obituary/ObituaryService.java
+++ b/src/main/java/com/caronte/caronte/obituary/ObituaryService.java
@@ -177,7 +177,9 @@ public class ObituaryService {
         obituary.setImageTemplate(imageTemplate);
         obituary.setDeathCertificate(certificate);
         obituary.setWordColor(word_color);
-        return obituaryRepository.save(obituary);
+        obituary = obituaryRepository.save(obituary);
+        obituaryRepository.flush();
+        return obituary;
     }
     @Transactional
     public void deleteObituaryByCustomer(Long customerId, Long obituaryId) {
@@ -197,7 +199,9 @@ public class ObituaryService {
 
     @Transactional
     public Obituary updateObituary(Obituary obituary) {
-        return obituaryRepository.save(obituary);
+        Obituary updatedObituary = obituaryRepository.save(obituary);
+        obituaryRepository.flush();
+        return updatedObituary;
     }
 
     @Transactional

--- a/src/main/java/com/caronte/caronte/receiver/ReceiverService.java
+++ b/src/main/java/com/caronte/caronte/receiver/ReceiverService.java
@@ -25,8 +25,7 @@ public class ReceiverService {
         receiver.setTelephone(telephone);
         receiver.setEmail(email);
         receiver.setObituary(obituary);
-        receiver = receiverRepository.save(receiver);
-        receiverRepository.flush();
+        receiver = receiverRepository.saveAndFlush(receiver);
         return receiver;
     }
     @Transactional
@@ -36,7 +35,7 @@ public class ReceiverService {
     }
     @Transactional(readOnly = true)
     public List<ReceiverResponseDTO> getReceiversByObituaryId(Obituary obituary) {
-        List<ReceiverResponseDTO> receivers = new ArrayList();
+        List<ReceiverResponseDTO> receivers = new ArrayList<>();
         List<Receiver> receiversList = receiverRepository.findByObituary(obituary);
         for (Receiver receiver : receiversList) {
             ReceiverResponseDTO receiverResponseDTO = new ReceiverResponseDTO();

--- a/src/main/java/com/caronte/caronte/receiver/ReceiverService.java
+++ b/src/main/java/com/caronte/caronte/receiver/ReceiverService.java
@@ -25,7 +25,9 @@ public class ReceiverService {
         receiver.setTelephone(telephone);
         receiver.setEmail(email);
         receiver.setObituary(obituary);
-        return receiverRepository.save(receiver);
+        receiver = receiverRepository.save(receiver);
+        receiverRepository.flush();
+        return receiver;
     }
     @Transactional
     public void deleteReceiversByObituaryId(Obituary obituary) {


### PR DESCRIPTION
Flush methods have been added to services related to creating and editing obituaries, as there were some issues with obituary templates and receivers.